### PR TITLE
Super basic client/server

### DIFF
--- a/jb-client/go.mod
+++ b/jb-client/go.mod
@@ -1,0 +1,3 @@
+module github.com/harrison-e/jukebox/jb-client
+
+go 1.15

--- a/jb-client/jb-client.go
+++ b/jb-client/jb-client.go
@@ -1,0 +1,24 @@
+package main 
+
+import (
+  "fmt"
+  "io/ioutil"
+  "net/http"
+)
+
+func main() {
+  resp, err := http.Get("http://localhost:8080/Go")
+  if err != nil {
+    fmt.Println("HTTP Get Error:", err)
+    return
+  }
+  defer resp.Body.Close()
+
+  body, err := ioutil.ReadAll(resp.Body)
+  if err != nil {
+    fmt.Println("Error reading body:", err)
+    return
+  }
+
+  fmt.Println("Server says:", string(body))
+}

--- a/jb-server/go.mod
+++ b/jb-server/go.mod
@@ -1,0 +1,3 @@
+module github.com/harrison-e/jukebox/jb-server
+
+go 1.15

--- a/jb-server/jb-server.go
+++ b/jb-server/jb-server.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+  "fmt"
+  "net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+  fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+}
+
+func main() {
+  http.HandleFunc("/", handler)
+  fmt.Println("Server starting on :8080")
+
+  if err := http.ListenAndServe(":8080", nil); err != nil {
+    fmt.Println("Error starting server:", err)
+  }
+}


### PR DESCRIPTION
## Changes
- Added `jb-client/`, to contain Jukebox TUI client (in Go)
- Added `jb-server/`, to contain Jukebox server (in Go)
- Added basic HTTP client/server code

## Testing
To test interaction between `jb-server` and `jb-client`:
1. Go to `jb-server/` directory, and type `go run .` to start the server
2. In another window, go to `jb-client/` directory, and type `go run .` to send a client request to the server